### PR TITLE
Fix CLI import error

### DIFF
--- a/interfaces/cli_interface.py
+++ b/interfaces/cli_interface.py
@@ -1,7 +1,13 @@
 # cli_interface.py
 
 import logging
-from agency import run_agency
+import os
+import sys
+
+# Ensure the project root is on the path when running directly
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from main import run_agency
 
 # Logging setup
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- correct module import in `cli_interface.py`
- ensure the CLI can locate the project root when executed directly

## Testing
- `python interfaces/cli_interface.py` *(fails to run due to missing dependencies but import error resolved)*

------
https://chatgpt.com/codex/tasks/task_e_684ba1d507008324aa31a634bb2eeb0c