### PR TITLE
Fix missing python-dotenv dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ All while using:
 - Docker (for deployment/testing)
 - OpenAI API key (for GPT-4 review agent)
 - Optional: Ollama running Qwen2 or Codestral models (the `setup.sh` script pulls a base model automatically)
+- `python-dotenv` for loading `.env` files
 
 ## 🔌 Setup
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai
 requests
 mysql-connector-python
 flask
+python-dotenv


### PR DESCRIPTION
## Summary
- add `python-dotenv` to requirements
- document dependency in README

## Testing
- `pytest -q`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6851e349d14c8324a7f004e64e67d7e5