### PR TITLE
Add PyQt interface with test

### DIFF
--- a/interfaces/qt_interface.py
+++ b/interfaces/qt_interface.py
@@ -1,0 +1,42 @@
+from PyQt6 import QtWidgets, QtCore
+import sys
+from main import run_agency
+import builtins
+
+class QtApp:
+    def __init__(self):
+        self.app = QtWidgets.QApplication(sys.argv)
+        self.window = QtWidgets.QWidget()
+        self.window.setWindowTitle("The Agency Qt Interface")
+        self.layout = QtWidgets.QVBoxLayout()
+        self.prompt_edit = QtWidgets.QTextEdit()
+        self.prompt_edit.setPlaceholderText("Describe the project you want built...")
+        self.run_button = QtWidgets.QPushButton("Run")
+        self.output_area = QtWidgets.QTextEdit()
+        self.output_area.setReadOnly(True)
+        self.layout.addWidget(self.prompt_edit)
+        self.layout.addWidget(self.run_button)
+        self.layout.addWidget(self.output_area)
+        self.window.setLayout(self.layout)
+        self.run_button.clicked.connect(self.handle_run)
+
+    def handle_run(self):
+        prompt = self.prompt_edit.toPlainText().strip()
+        if not prompt:
+            QtWidgets.QMessageBox.warning(self.window, "Input Required", "Please enter a prompt.")
+            return
+        self.output_area.append(f"Running: {prompt}")
+        orig_input = builtins.input
+        builtins.input = lambda _='': 'no'
+        try:
+            run_agency(prompt)
+            self.output_area.append("Finished")
+        finally:
+            builtins.input = orig_input
+
+    def run(self):
+        self.window.show()
+        sys.exit(self.app.exec())
+
+if __name__ == "__main__":
+    QtApp().run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ mysql-connector-python
 flask
 python-dotenv
 radon
+
+PyQt6

--- a/tests/test_qt_interface.py
+++ b/tests/test_qt_interface.py
@@ -1,0 +1,8 @@
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from interfaces.qt_interface import QtApp
+
+
+def test_window_title():
+    app = QtApp()
+    assert app.window.windowTitle() == "The Agency Qt Interface"


### PR DESCRIPTION
## Summary
- provide a simple Qt interface for running the agency
- include PyQt dependency
- test that the window loads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68585a3860948324991d65166209b78b