### PR TITLE
Fix Qt test import path

### DIFF
--- a/tests/test_qt_interface.py
+++ b/tests/test_qt_interface.py
@@ -1,5 +1,12 @@
 import os
+import sys
+
+# Ensure project root is on the import path when running this file directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Allow Qt to run in headless mode during tests
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
 from interfaces.qt_interface import QtApp
 
 


### PR DESCRIPTION
## Summary
- ensure project root is discoverable when running `tests/test_qt_interface.py`
- keep Qt test in headless mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858a91b6464832490403e5d3b24ba44