### PR TITLE
Ignore local config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+config.py


### PR DESCRIPTION
## Summary
- ignore `config.py` so local configs aren't tracked

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b83c06308324acd19fc51f6eb48e