### PR TITLE
Switch DB to SQLite

### DIFF
--- a/Project_Blueprint.html
+++ b/Project_Blueprint.html
@@ -47,7 +47,7 @@
         <h3>2.1 Agent Kernel</h3>
         <ul>
             <li><strong>Skill Layer:</strong> Modular Python functions (e.g., <code>scrape_site()</code>, <code>query_api()</code>, <code>generate_image(prompt)</code>) loaded via plugin system.</li>
-            <li><strong>Memory Layer:</strong> Fast-access working memory (in-RAM dicts), persistent symbolic memory (MySQL), semantic memory (FAISS).</li>
+            <li><strong>Memory Layer:</strong> Fast-access working memory (in-RAM dicts), persistent symbolic memory (SQLite), semantic memory (FAISS).</li>
             <li><strong>Execution Engine:</strong> Event-driven task loop with context switching and structured retry logic.</li>
             <li><strong>Ethical Guardrails:</strong> Decorators (e.g., <code>@requires_ethics_check</code>) and runtime hooks block disallowed actions. Hooks register at kernel init; use dynamic imports and tracing to enforce constraints.</li>
         </ul>
@@ -65,8 +65,8 @@
         <h3>2.4 Deployment Modes</h3>
         <ul>
             <li><strong>Local Mode:</strong> SQLite fallback, minimal runtime.</li>
-            <li><strong>LAN Mode:</strong> MySQL + shared mount point (e.g., NFS). Agents use <code>hostname</code>-based node identity.</li>
-            <li><strong>Hybrid Mode:</strong> Cloud-mirrored MySQL/FAISS (read-only unless override). Cloud target TBD (S3-compatible).</li>
+            <li><strong>LAN Mode:</strong> SQLite on a shared mount point (e.g., NFS). Agents use <code>hostname</code>-based node identity.</li>
+            <li><strong>Hybrid Mode:</strong> Cloud-mirrored SQLite/FAISS (read-only unless override). Cloud target TBD (S3-compatible).</li>
         </ul>
     </section>
 

--- a/Project_Blueprint.txt
+++ b/Project_Blueprint.txt
@@ -10,7 +10,7 @@ Project Blueprint: The Agency (Rev 2.5)
 2.1 Agent Kernel
 
     Skill Layer: Modular Python functions (e.g., scrape_site(), query_api(), generate_image(prompt)) loaded via plugin system.
-    Memory Layer: Fast-access working memory (in-RAM dicts), persistent symbolic memory (MySQL), semantic memory (FAISS).
+    Memory Layer: Fast-access working memory (in-RAM dicts), persistent symbolic memory (SQLite), semantic memory (FAISS).
     Execution Engine: Event-driven task loop with context switching and structured retry logic.
     Ethical Guardrails: Decorators (e.g., @requires_ethics_check) and runtime hooks block disallowed actions. Hooks register at kernel init; use dynamic imports and tracing to enforce constraints.
 
@@ -28,8 +28,8 @@ Project Blueprint: The Agency (Rev 2.5)
 2.4 Deployment Modes
 
     Local Mode: SQLite fallback, minimal runtime.
-    LAN Mode: MySQL + shared mount point (e.g., NFS). Agents use hostname-based node identity.
-    Hybrid Mode: Cloud-mirrored MySQL/FAISS (read-only unless override). Cloud target TBD (S3-compatible).
+    LAN Mode: SQLite on a shared mount point (e.g., NFS). Agents use hostname-based node identity.
+    Hybrid Mode: Cloud-mirrored SQLite/FAISS (read-only unless override). Cloud target TBD (S3-compatible).
 
 3. Intelligence & Learning
 3.1 Self-Improvement Loop

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The-Agency/
 │   ├── reviewer.py        # Uses GPT-4 to review and give feedback
 │   ├── fixer.py           # Uses test feedback to auto-repair code
 │   ├── deployer.py        # Creates Docker/CI/CD and deploys
-│   ├── memory.py          # MySQL-based memory and task recall
+│   ├── memory.py          # SQLite-based memory and task recall
 │   └── task_manager.py    # Maintains current task list and their status
 ├── tools/                 # Folder: shared utilities
 │   ├── context_loader.py  # Retrieves relevant code snippets or docs
@@ -68,11 +68,11 @@ The Agency combines multiple specialized AI agents:
 | `reviewer.py` – **ReviewerAgent** | Provides GPT‑4 based code reviews |
 | `fixer.py` – **FixerAgent** | Applies automated fixes based on test results |
 | `deployer.py` – **DeployerAgent** | Builds Docker images and launches containers |
-| `memory.py` – **MemoryManager** | Persists state using an optional MySQL backend |
+| `memory.py` – **MemoryManager** | Persists state using an optional SQLite backend |
 | `task_manager.py` – **TaskManager** | Tracks outstanding and completed tasks |
 
 All while using:
-- 🧠 MySQL-based persistent memory
+- 🧠 SQLite-based persistent memory
 - 🗂️ A modular architecture for future agent extensions
 - 🛡️ Open-source LLMs (via Ollama) for code generation with GPT-4 used for critical review.
   Agents default to these local models but can target OpenAI by setting `CODE_MODEL`.
@@ -102,7 +102,7 @@ cd The-Agency
 ./install_and_test_ollama.sh  # installs Ollama and verifies the Qwen model
 ./deploy.sh   # updates code, installs deps if needed, then launches The Agency
 python tools/env_check.py     # verify Python and Docker
-python tools/db_setup.py      # initialize MySQL database
+python tools/db_setup.py      # initialize SQLite database
 ```
 
 ## 🧠 Configuration
@@ -111,8 +111,7 @@ Edit `config.py` or use environment variables:
 export GPT4_API_KEY=your-key
 export OLLAMA_MODEL=qwen:latest
 export CODE_MODEL=$OLLAMA_MODEL  # defaults to Ollama model
-export MYSQL_USER=agency
-export MYSQL_PASSWORD=agency123
+export SQLITE_PATH=the_agency.db
 export MAX_PROJECT_DIR_SIZE_MB=100
 ```
 
@@ -130,13 +129,11 @@ python interfaces/web_dashboard.py
 ```
 
 ## 🐳 Run with Docker Compose
-This repository ships with a `docker-compose.yml` that runs The Agency and MySQL
-in separate containers. Build and start everything with:
+This repository ships with a `docker-compose.yml` that runs The Agency. Build and start everything with:
 ```bash
 docker compose up --build
 ```
-The application container automatically connects to the `mysql` service defined
-in the compose file.
+The application container stores persistent state in a local SQLite database.
 
 ## 🧪 Workflow
 1. Accepts prompt from user (chat or file)

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## Phase 0: Environment Setup
 - [x] Install Python 3.10+ and Docker
-- [x] Configure MySQL and vector database
+- [x] Configure SQLite and vector database
 - [x] Pull local models via Ollama
 - [x] Run `deploy.sh` to verify setup
 

--- a/config.py
+++ b/config.py
@@ -18,14 +18,9 @@ class Config:
     GPT4_MODEL = os.getenv("GPT4_MODEL", "gpt-4o")
     GPT4_API_URL = os.getenv("GPT4_API_URL", "https://api.openai.com/v1/chat/completions")
 
-    # MySQL memory system
-    # Default to the Docker compose service name so MySQL can run in a
-    # separate container. Override with MYSQL_HOST if running locally.
-    MYSQL_HOST = os.getenv("MYSQL_HOST", "mysql")
-    MYSQL_PORT = int(os.getenv("MYSQL_PORT", 3306))
-    MYSQL_USER = os.getenv("MYSQL_USER", "agency")
-    MYSQL_PASSWORD = os.getenv("MYSQL_PASSWORD", "agency123")
-    MYSQL_DATABASE = os.getenv("MYSQL_DATABASE", "the_agency")
+    # SQLite memory system
+    # Path to the local SQLite database used for persistent memory.
+    SQLITE_PATH = os.getenv("SQLITE_PATH", "the_agency.db")
 
     # Paths
     PROJECTS_DIR = os.getenv("PROJECTS_DIR", "./projects")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,26 +6,5 @@ services:
     volumes:
       - .:/app
     environment:
-      - MYSQL_HOST=mysql
-      - MYSQL_PORT=3306
-      - MYSQL_USER=agency
-      - MYSQL_PASSWORD=agency123
-      - MYSQL_DATABASE=the_agency
-    depends_on:
-      - mysql
+      - SQLITE_PATH=the_agency.db
     command: python interfaces/cli_interface.py
-  mysql:
-    image: mysql:8.0
-    container_name: the-agency-mysql
-    restart: unless-stopped
-    environment:
-      - MYSQL_DATABASE=the_agency
-      - MYSQL_USER=agency
-      - MYSQL_PASSWORD=agency123
-      - MYSQL_ROOT_PASSWORD=rootpass
-    volumes:
-      - mysql_data:/var/lib/mysql
-    ports:
-      - "3306:3306"
-volumes:
-  mysql_data:

--- a/install_ubuntu.sh
+++ b/install_ubuntu.sh
@@ -12,21 +12,10 @@ sudo apt-get install -y \
     python3 \
     python3-venv \
     python3-pip \
-    mysql-server \
     git \
     curl \
     docker.io
 
-# Start MySQL service
-sudo systemctl enable --now mysql
-
-# Set up MySQL database and user
-sudo mysql <<MYSQL
-CREATE DATABASE IF NOT EXISTS the_agency;
-CREATE USER IF NOT EXISTS 'agency'@'localhost' IDENTIFIED BY 'agency123';
-GRANT ALL PRIVILEGES ON the_agency.* TO 'agency'@'localhost';
-FLUSH PRIVILEGES;
-MYSQL
 
 # Set up Python virtual environment
 python3 -m venv .venv

--- a/install_web_stack.sh
+++ b/install_web_stack.sh
@@ -2,15 +2,10 @@
 set -euo pipefail
 
 # install_web_stack.sh
-# Installs and configures MySQL, phpMyAdmin, and Apache for The Agency project.
+# Installs SQLite and Apache for The Agency project.
 
-MYSQL_PKG="mysql-server"
-PHPMYADMIN_PKG="phpmyadmin"
+SQLITE_PKG="sqlite3"
 APACHE_PKG="apache2"
-
-DB_NAME="${MYSQL_DATABASE:-the_agency}"
-DB_USER="${MYSQL_USER:-agency}"
-DB_PASS="${MYSQL_PASSWORD:-agency123}"
 
 sudo apt-get update
 
@@ -22,28 +17,9 @@ install_pkg() {
     fi
 }
 
-install_pkg "$MYSQL_PKG"
+install_pkg "$SQLITE_PKG"
 install_pkg "$APACHE_PKG"
-install_pkg "$PHPMYADMIN_PKG" php-mysql
 
-sudo systemctl enable --now mysql
 sudo systemctl enable --now apache2
-
-sudo mysql <<MYSQL
-CREATE DATABASE IF NOT EXISTS $DB_NAME;
-CREATE USER IF NOT EXISTS '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASS';
-GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER'@'localhost';
-FLUSH PRIVILEGES;
-MYSQL
-
-# Basic tests
-mysql -u "$DB_USER" -p"$DB_PASS" -e "SELECT 1;" "$DB_NAME"
-
-if curl -s -o /dev/null -w "%{http_code}" http://localhost/phpmyadmin/ | grep -q 200; then
-    echo "phpMyAdmin reachable."
-else
-    echo "phpMyAdmin test failed" >&2
-    exit 1
-fi
 
 echo "Installation and configuration complete."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 openai
 requests
-mysql-connector-python
 flask
 python-dotenv
 radon

--- a/tools/db_setup.py
+++ b/tools/db_setup.py
@@ -1,27 +1,18 @@
-"""Simple MySQL database initializer."""
-import mysql.connector
-from mysql.connector import Error
+"""Simple SQLite database initializer."""
+import sqlite3
 from config import Config
 
 
 def init_database():
     try:
-        conn = mysql.connector.connect(
-            host=Config.MYSQL_HOST,
-            port=Config.MYSQL_PORT,
-            user=Config.MYSQL_USER,
-            password=Config.MYSQL_PASSWORD,
-        )
+        conn = sqlite3.connect(Config.SQLITE_PATH)
         cursor = conn.cursor()
-        cursor.execute(f"CREATE DATABASE IF NOT EXISTS {Config.MYSQL_DATABASE}")
-        cursor.execute(f"USE {Config.MYSQL_DATABASE}")
         cursor.execute(
-            "CREATE TABLE IF NOT EXISTS logs (" 
-            "id INT AUTO_INCREMENT PRIMARY KEY, entry TEXT)"
+            "CREATE TABLE IF NOT EXISTS logs (id INTEGER PRIMARY KEY AUTOINCREMENT, entry TEXT)"
         )
         conn.commit()
         print("Database initialized")
-    except Error as e:
+    except sqlite3.Error as e:
         print(f"DB init failed: {e}")
     finally:
         try:


### PR DESCRIPTION
## Summary
- remove MySQL dependency and use SQLite instead
- update configuration and MemoryManager for SQLite
- simplify DB setup script
- clean up install scripts and docker-compose
- document SQLite usage across docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d34b79bbc83248867ad451506fcfa