### PR TITLE
Launch web dashboard from deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,8 @@ model instead, set `CODE_MODEL` to a chat model like `gpt-4o`.
 ## 🧪 Run via Terminal
 ```bash
 python interfaces/cli_interface.py
-# or let the deploy script handle setup and launching
+# or let the deploy script handle setup and launching (opens the dashboard)
 ./deploy.sh
-# optional: launch the Flask dashboard
-python interfaces/web_dashboard.py
 ```
 
 ## 🐳 Run with Docker Compose

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,5 +22,21 @@ source .venv/bin/activate
 echo "Installing Python dependencies..."
 pip install -r requirements.txt
 
-echo "Starting The Agency..."
+echo "Launching web dashboard..."
+python interfaces/web_dashboard.py &
+DASHBOARD_PID=$!
+
+# Give the server a moment to start before opening the browser
+sleep 2
+URL="http://localhost:5000"
+if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$URL" >/dev/null 2>&1 &
+elif command -v open >/dev/null 2>&1; then
+    open "$URL" >/dev/null 2>&1 &
+fi
+
+echo "Starting The Agency CLI..."
 python interfaces/cli_interface.py
+
+# Stop the dashboard when the CLI exits
+kill "$DASHBOARD_PID" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- update `deploy.sh` to launch the Flask dashboard and open a browser
- mention auto-launch in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d436154108324a16e316a41e2caa4