### PR TITLE
Add feature modules and tests

### DIFF
--- a/agents/deployer.py
+++ b/agents/deployer.py
@@ -105,6 +105,24 @@ class DeployerAgent(BaseAgent):
         except FileNotFoundError:
             logger.error(f"❌ {self.container_tool} not found. Is it installed and in your PATH?")
 
+    def auto_push_to_github(self, repo_url: str) -> None:
+        """Push the generated project to a GitHub repository."""
+        logger.info(f"📤 Pushing project to {repo_url}")
+        proj = self.config.PROJECTS_DIR
+        cmds = [
+            ["git", "init"],
+            ["git", "add", "-A"],
+            ["git", "commit", "-m", "auto deploy"],
+            ["git", "remote", "add", "origin", repo_url],
+            ["git", "push", "-u", "origin", "main"]
+        ]
+        for cmd in cmds:
+            try:
+                subprocess.run(cmd, cwd=proj, check=True)
+            except Exception as e:
+                logger.error(f"❌ Git command failed: {e}")
+                break
+
     def _run_container(self, image_name: str = "the-agency-app", port: str = "8080") -> None:
         """
         Runs the Docker container.

--- a/agents/extensions/manager.py
+++ b/agents/extensions/manager.py
@@ -1,0 +1,39 @@
+import importlib.util
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+class ExtensionManager:
+    """Simple plugin loader for agent extensions."""
+
+    REGISTRY = {}
+
+    @classmethod
+    def load_extensions(cls, directory: str) -> None:
+        for fname in os.listdir(directory):
+            if fname.endswith('.py') and fname != '__init__.py':
+                path = os.path.join(directory, fname)
+                mod_name = os.path.splitext(fname)[0]
+                try:
+                    spec = importlib.util.spec_from_file_location(mod_name, path)
+                    mod = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(mod)  # type: ignore
+                    if hasattr(mod, 'register'):
+                        mod.register(cls)
+                        logger.info(f"Loaded extension {fname}")
+                except Exception as e:
+                    logger.error(f"Failed to load {fname}: {e}")
+
+    @classmethod
+    def register(cls, name: str, obj) -> None:
+        cls.REGISTRY[name] = obj
+
+    @classmethod
+    def get(cls, name: str):
+        return cls.REGISTRY.get(name)
+
+    @classmethod
+    def list_extensions(cls):
+        return list(cls.REGISTRY.keys())

--- a/agents/marketplace.py
+++ b/agents/marketplace.py
@@ -1,0 +1,17 @@
+class AgentMarketplace:
+    """Registry for sharing and instantiating agents."""
+
+    def __init__(self):
+        self._agents = {}
+
+    def register_agent(self, name: str, agent_cls):
+        self._agents[name] = agent_cls
+
+    def list_agents(self):
+        return list(self._agents.keys())
+
+    def create_agent(self, name: str, config, memory):
+        cls = self._agents.get(name)
+        if not cls:
+            raise ValueError(f"Unknown agent: {name}")
+        return cls(config, memory)

--- a/interfaces/web_dashboard.py
+++ b/interfaces/web_dashboard.py
@@ -12,6 +12,22 @@ TEMPLATE = """
   <input name="prompt" style="width:300px" placeholder="Enter prompt"/>
   <input type="submit" value="Run" />
 </form>
+<h3>Upload Blueprint</h3>
+<form id="up" action="/upload" method="post" enctype="multipart/form-data">
+  <input type="file" name="file" />
+  <input type="submit" value="Upload" />
+</form>
+<script>
+document.addEventListener('dragover', e=>e.preventDefault());
+document.addEventListener('drop', e=>{
+  e.preventDefault();
+  const file=e.dataTransfer.files[0];
+  if(!file) return;
+  const form=new FormData();
+  form.append('file', file);
+  fetch('/upload',{method:'POST',body:form});
+});
+</script>
 <h2>Logs</h2>
 <pre>{{logs}}</pre>
 """
@@ -36,6 +52,16 @@ def run():
     if prompt:
         threading.Thread(target=run_agency, args=(prompt,), daemon=True).start()
     return "Started", 202
+
+
+@app.route("/upload", methods=["POST"])
+def upload():
+    file = request.files.get("file")
+    if file:
+        content = file.read().decode("utf-8", errors="ignore").strip()
+        if content:
+            threading.Thread(target=run_agency, args=(content,), daemon=True).start()
+    return "Uploaded", 202
 
 
 def _tail_log(path, lines=20):

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -1,0 +1,63 @@
+import os
+import types
+import io
+import tempfile
+import subprocess
+from agents.deployer import DeployerAgent
+from agents.marketplace import AgentMarketplace
+from agents.extensions.manager import ExtensionManager
+from tools.retriever import SimpleRetriever
+from interfaces.web_dashboard import app
+from agents.memory import MemoryManager
+
+class DummyConfig:
+    GPT4_API_KEY = "k"
+    OLLAMA_API_URL = "http://localhost"
+    PROJECTS_DIR = tempfile.mkdtemp()
+
+
+def test_extension_manager_load(tmp_path, monkeypatch):
+    ext_dir = tmp_path / "ext"
+    ext_dir.mkdir()
+    (ext_dir / "mod.py").write_text("def register(m): m.register('x','y')")
+    ExtensionManager.REGISTRY.clear()
+    ExtensionManager.load_extensions(str(ext_dir))
+    assert ExtensionManager.get('x') == 'y'
+
+
+def test_marketplace_register_and_create():
+    class DummyAgent:
+        def __init__(self, c, m):
+            self.cfg = c
+    mp = AgentMarketplace()
+    mp.register_agent('dummy', DummyAgent)
+    assert 'dummy' in mp.list_agents()
+    agent = mp.create_agent('dummy', None, None)
+    assert isinstance(agent, DummyAgent)
+
+
+def test_deployer_auto_push(monkeypatch):
+    calls = []
+    def fake_run(cmd, cwd=None, check=False):
+        calls.append(cmd)
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    dep = DeployerAgent(DummyConfig, MemoryManager())
+    dep.auto_push_to_github('git@example.com:repo.git')
+    assert any('git' in c[0] for c in calls)
+
+
+def test_retriever_search(tmp_path):
+    d = tmp_path
+    f1 = d / 'a.txt'; f1.write_text('hello world')
+    f2 = d / 'b.txt'; f2.write_text('another file')
+    r = SimpleRetriever()
+    r.index_folder(str(d))
+    results = r.search('hello')
+    assert results and str(f1) in results[0]
+
+
+def test_dashboard_upload_route(tmp_path):
+    client = app.test_client()
+    data = {'file': (io.BytesIO(b'test prompt'), 'bp.txt')}
+    resp = client.post('/upload', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 202

--- a/tools/retriever.py
+++ b/tools/retriever.py
@@ -1,0 +1,32 @@
+import os
+import logging
+from difflib import SequenceMatcher
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+class SimpleRetriever:
+    """Index and search text documents with basic similarity scoring."""
+
+    def __init__(self):
+        self.index = {}
+
+    def index_folder(self, directory: str, exts=(".md", ".txt")) -> None:
+        for root, _, files in os.walk(directory):
+            for name in files:
+                if name.endswith(exts):
+                    path = os.path.join(root, name)
+                    try:
+                        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                            self.index[path] = f.read().lower()
+                    except Exception as e:
+                        logger.error(f"Failed to read {path}: {e}")
+
+    def search(self, query: str, top_k: int = 3):
+        query = query.lower()
+        scored = []
+        for path, text in self.index.items():
+            score = SequenceMatcher(None, query, text).ratio()
+            scored.append((score, path))
+        scored.sort(reverse=True)
+        return [p for _, p in scored[:top_k]]


### PR DESCRIPTION
## Summary
- add extension manager for plugin loading
- add marketplace registry for agents
- support GitHub auto push in deployer
- allow blueprint drag/drop on dashboard
- implement a simple document retriever
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d47381164832485f32dc9b28f7721