### PR TITLE
Fix CLI EOF loop

### DIFF
--- a/interfaces/cli_interface.py
+++ b/interfaces/cli_interface.py
@@ -51,6 +51,11 @@ def launch_cli(input_func=input, output_func=print):
             logging.info("CLI shutdown by user.")
             break
 
+        except EOFError:
+            output_func("\n👋 No input detected. Exiting.")
+            logging.info("CLI received EOF; exiting.")
+            break
+
         except Exception as e:
             output_func(f"🔥 An unexpected error occurred: {e}")
             logging.exception("Unexpected exception in CLI loop.")


### PR DESCRIPTION
## Summary
- exit gracefully when stdin closes in `cli_interface.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d66abe6208324a994bcc336d6fc34