### PR TITLE
Fix EOF handling in CLI

### DIFF
--- a/interfaces/cli_interface.py
+++ b/interfaces/cli_interface.py
@@ -51,6 +51,11 @@ def launch_cli(input_func=input, output_func=print):
             logging.info("CLI shutdown by user.")
             break
 
+        except EOFError:
+            output_func("\n👋 No input received. Exiting CLI.")
+            logging.info("CLI received EOF, shutting down.")
+            break
+
         except Exception as e:
             output_func(f"🔥 An unexpected error occurred: {e}")
             logging.exception("Unexpected exception in CLI loop.")


### PR DESCRIPTION
## Summary
- handle `EOFError` in `cli_interface` to exit gracefully

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d69d916d083249220d4733053d47d