### PR TITLE
Fix web dashboard import path

### DIFF
--- a/interfaces/web_dashboard.py
+++ b/interfaces/web_dashboard.py
@@ -2,6 +2,11 @@ from flask import Flask, request, render_template_string
 import threading
 import time
 import os
+import sys
+
+# Ensure the project root is on the Python path when run directly
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from main import run_agency
 
 TEMPLATE = """


### PR DESCRIPTION
## Summary
- ensure `interfaces/web_dashboard.py` adds the project root to `sys.path`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6b42166c8324b73039bd24a46903