### PR TITLE
Add API connectivity check on startup

### DIFF
--- a/tests/test_api_connections.py
+++ b/tests/test_api_connections.py
@@ -1,0 +1,29 @@
+import logging
+import requests
+import types
+
+from main import check_api_connections
+
+class DummyConfig:
+    OLLAMA_API_URL = "http://localhost:12345"
+    GPT4_API_URL = "http://localhost:12346"
+    REQUEST_TIMEOUT = 0.1
+
+def test_check_api_connections_failure(monkeypatch, caplog):
+    def fail(url, timeout):
+        raise requests.ConnectionError("fail")
+    monkeypatch.setattr("main.requests.get", fail)
+    with caplog.at_level(logging.ERROR):
+        ok = check_api_connections(DummyConfig)
+    assert not ok
+    assert "Cannot reach" in caplog.text
+
+def test_check_api_connections_success(monkeypatch, caplog):
+    class Resp:
+        status_code = 200
+    monkeypatch.setattr("main.requests.get", lambda url, timeout: Resp())
+    with caplog.at_level(logging.ERROR):
+        ok = check_api_connections(DummyConfig)
+    assert ok
+    assert not caplog.records
+


### PR DESCRIPTION
## Summary
- ensure `requests` is available for API health checks
- add `check_api_connections` helper and call it during startup
- verify connectivity logic with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d82683e3483249d85baa0d035d0eb