### PR TITLE
Add GitHub API agent and project resume menu

### DIFF
--- a/agents/github_agent.py
+++ b/agents/github_agent.py
@@ -1,0 +1,44 @@
+import logging
+import requests
+from agents.agent_base import BaseAgent
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+class GithubAgent(BaseAgent):
+    """Simple wrapper around GitHub's REST API."""
+
+    def __init__(self, config, memory):
+        super().__init__(config, memory)
+        self.token = getattr(config, "GITHUB_TOKEN", "")
+        self.base_url = getattr(config, "GITHUB_API_URL", "https://api.github.com")
+        self.headers = {"Authorization": f"token {self.token}"} if self.token else {}
+
+    def generate_plan(self, user_prompt: str):
+        return {}
+
+    def _request(self, method: str, path: str, **kwargs):
+        url = f"{self.base_url}{path}"
+        kwargs.setdefault("headers", self.headers)
+        try:
+            resp = requests.request(method, url, **kwargs)
+            if resp.ok:
+                return resp.json()
+            logger.error(f"GitHub API error {resp.status_code}: {resp.text}")
+        except Exception as e:  # pragma: no cover - network dependent
+            logger.error(f"GitHub request failed: {e}")
+        return None
+
+    def list_repos(self):
+        data = self._request("GET", "/user/repos")
+        if isinstance(data, list):
+            return [r.get("name") for r in data]
+        return []
+
+    def create_repo(self, name: str, private: bool = False):
+        payload = {"name": name, "private": private}
+        return self._request("POST", "/user/repos", json=payload)
+
+    def create_issue(self, repo: str, title: str, body: str = ""):
+        payload = {"title": title, "body": body}
+        return self._request("POST", f"/repos/{repo}/issues", json=payload)

--- a/config.py
+++ b/config.py
@@ -38,3 +38,7 @@ class Config:
 
     # Flags
     USE_GPT4_FOR_QA = True
+
+    # GitHub integration
+    GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "")
+    GITHUB_API_URL = os.getenv("GITHUB_API_URL", "https://api.github.com")

--- a/interfaces/cli_interface.py
+++ b/interfaces/cli_interface.py
@@ -21,41 +21,63 @@ logging.basicConfig(
 
 
 def launch_cli(input_func=input, output_func=print):
-    """
-    Launches the CLI interface for The Agency.
-    Accepts optional input/output functions for testability.
-    """
+    """Interactive menu for running and resuming projects."""
     output_func("🕶️  Welcome to The Agency Terminal Interface")
-    output_func("Type your request like you're the boss. I’ll handle the rest.")
-    output_func("To exit, press Ctrl+C\n")
+    output_func("Type your request like you're the boss. I'll handle the rest.")
 
     while True:
+        output_func("\nSelect an option:")
+        output_func("1) New project")
+        output_func("2) Continue project")
+        output_func("3) Quit")
         try:
-            prompt = input_func("📝 What would you like The Agency to build?\n> ").strip()
+            choice = input_func("> ").strip().lower()
 
-            if not prompt:
-                output_func("⚠️  Please enter a valid request.")
+            if choice in {"3", "q", "quit", "exit"}:
+                output_func("👋 Shutting down The Agency CLI.")
+                logging.info("CLI shutdown by user.")
+                break
+
+            if choice in {"1", "n", "new"}:
+                prompt = input_func("📝 What would you like The Agency to build?\n> ").strip()
+                if not prompt:
+                    output_func("⚠️  Please enter a valid request.")
+                    continue
+                logging.info(f"User input: {prompt}")
+                run_agency(prompt)
                 continue
 
-            if prompt.lower() in {"help", "?"}:
-                output_func("ℹ️  Enter a plain-English request to build software.")
-                output_func("    Example: A website to track planets using React + Flask.")
-                output_func("    Press Ctrl+C to exit.\n")
+            if choice in {"2", "c", "continue"}:
+                projects = os.listdir(Config.PROJECTS_DIR)
+                if not projects:
+                    output_func("No past projects found.")
+                    continue
+                for idx, name in enumerate(projects, 1):
+                    output_func(f"{idx}) {name}")
+                sel = input_func("Select project number: ").strip()
+                if not sel.isdigit() or int(sel) < 1 or int(sel) > len(projects):
+                    output_func("Invalid selection.")
+                    continue
+                project = projects[int(sel) - 1]
+                Config.PROJECTS_DIR = os.path.join(Config.PROJECTS_DIR, project)
+                prompt = input_func("📝 What would you like to do next?\n> ").strip()
+                if not prompt:
+                    output_func("⚠️  Please enter a valid request.")
+                    continue
+                logging.info(f"Continuing {project} with prompt: {prompt}")
+                run_agency(prompt)
                 continue
 
-            logging.info(f"User input: {prompt}")
-            run_agency(prompt)
+            output_func("Invalid option. Try again.")
 
         except KeyboardInterrupt:
             output_func("\n👋 Shutting down The Agency CLI.")
             logging.info("CLI shutdown by user.")
             break
-
         except EOFError:
             output_func("\n👋 No input detected. Exiting.")
             logging.info("CLI received EOF; exiting.")
             break
-
         except Exception as e:
             output_func(f"🔥 An unexpected error occurred: {e}")
             logging.exception("Unexpected exception in CLI loop.")

--- a/tests/test_github_and_cli.py
+++ b/tests/test_github_and_cli.py
@@ -1,0 +1,40 @@
+import sys
+import types
+
+import requests
+
+from agents.github_agent import GithubAgent
+from agents.memory import MemoryManager
+from interfaces import cli_interface
+
+class DummyConfig:
+    GPT4_API_KEY = 'k'
+    OLLAMA_API_URL = 'http://localhost'
+    GITHUB_API_URL = 'http://example.com'
+    GITHUB_TOKEN = 't'
+    PROJECTS_DIR = ''
+
+def test_github_agent_list(monkeypatch):
+    def fake_request(method, url, **kwargs):
+        class Resp:
+            ok = True
+            def json(self):
+                return [{'name': 'repo1'}]
+        return Resp()
+    monkeypatch.setattr(requests, 'request', fake_request)
+    agent = GithubAgent(DummyConfig, MemoryManager())
+    repos = agent.list_repos()
+    assert 'repo1' in repos
+
+
+def test_cli_continue_menu(tmp_path, monkeypatch):
+    DummyConfig.PROJECTS_DIR = str(tmp_path)
+    (tmp_path / 'proj1').mkdir()
+    inputs = iter(['2', '1', 'do something', '3'])
+    outputs = []
+    cli_interface.Config.PROJECTS_DIR = str(tmp_path)
+    cli_interface.launch_cli(input_func=lambda _: next(inputs), output_func=outputs.append)
+    joined = '\n'.join(outputs)
+    assert 'proj1' in joined
+    assert 'Shutting down' in joined
+


### PR DESCRIPTION
## Summary
- support GitHub API credentials in `Config`
- implement `GithubAgent` for basic GitHub interactions
- expand CLI with an interactive menu to continue past projects
- test GitHub agent and new CLI menu

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8a3b75ec8324a1e604c1a63d88ae